### PR TITLE
Add ads.txt for Google AdSense

### DIFF
--- a/static/ads.txt
+++ b/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-8547759384412640, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- provide ads.txt with Google AdSense publisher info so the site can verify ownership

## Testing
- `npm test` *(fails: Missing script "test"* )
- `npx prettier --parser markdown --check static/ads.txt`


------
https://chatgpt.com/codex/tasks/task_e_689e37ed17248328a7f591657d645e6f